### PR TITLE
fix: fix ValueError on python 3.8 due to missing logging encoding arg

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,10 +4,29 @@ import requests
 import re
 import logging
 import json
+import sys
 from dataclasses import dataclass
 from mutagen.mp3 import MP3
 from mutagen.id3 import ID3, APIC, error, TRCK
-logging.basicConfig(filename="spdl.log", filemode="a", level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', encoding="utf-8")
+
+if sys.version_info >= (3, 9):
+    logging.basicConfig(
+        filename="spdl.log",
+        filemode="a",
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        encoding="utf-8"
+    )
+else:
+    # Workaround for Python versions earlier than 3.9
+    file_handler = logging.FileHandler("spdl.log", mode="a", encoding="utf-8")
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    file_handler.setFormatter(formatter)
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logger.addHandler(file_handler)
+
 CUSTOM_HEADER = {
     'Host': 'api.spotifydown.com',
     'Referer': 'https://spotifydown.com/',


### PR DESCRIPTION
This PR solves #27.

In Python version 3.8, using the `encoding` parameter in `logging.basicConfig` raises a `ValueError` because the `encoding` argument was only introduced in Python 3.9. 

### Solution
This PR introduces a version check to apply the encoding argument conditionally:

- If the Python version is 3.9 or later: The code uses `logging.basicConfig` with the `encoding="utf-8"` parameter directly.

- If the Python version is earlier than 3.9: A workaround is applied by creating a `FileHandler` with `encoding="utf-8"` and adding it manually to the logger. This approach ensures UTF-8 logging support without raising compatibility errors in Python 3.8 and earlier.

### Code Changes
The code now checks the Python version using `sys.version_info`. Depending on the version, it either:

- Configures logging with `logging.basicConfig` (if 3.9 or later), or

- Sets up a `FileHandler` with UTF-8 encoding and manually adds it to the logger (if earlier than 3.9).

### Testing

The solution has been tested by running the logging setup on Python 3.8 and 3.9+ environments to verify:

- Compatibility and lack of errors in Python 3.8.

- Correct logging behavior with UTF-8 encoding in all supported versions.