### PR TITLE
playlist apis now require a token too

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,4 +6,10 @@ CUSTOM_HEADER = {
     'Origin': 'https://spotidownloader.com',
 }
 
+PURR_HEADER = {
+    'Host': 'simba.purr.rip',
+    'Referer': 'https://spotidownloader.com/',
+    'Origin': 'https://spotidownloader.com',
+}
+
 NAME_SANITIZE_REGEX = re.compile(r"[<>:\"\/\\|?*]")

--- a/downloader.py
+++ b/downloader.py
@@ -167,7 +167,7 @@ def remove_empty_files(outpath):
 def download_playlist_tracks(playlist_link, outpath, create_folder, trackname_convention, token, max_attempts=3, mode='playlist'):
     # print(f"\n{mode[0].upper()}{mode[1:]} link identified")
     print(f"\n{mode.capitalize()} link identified")
-    song_list_dict, playlist_name_old = get_playlist_info(playlist_link, trackname_convention, mode)
+    song_list_dict, playlist_name_old = get_playlist_info(playlist_link, trackname_convention, mode, token)
     playlist_name = re.sub(NAME_SANITIZE_REGEX, "_", playlist_name_old)
     if (playlist_name != playlist_name_old):
         print(f'\n"{playlist_name_old}" is not a valid folder name. Using "{playlist_name}" instead.')

--- a/downloader.py
+++ b/downloader.py
@@ -2,6 +2,7 @@ import os
 import re
 import requests
 import logging
+from config import PURR_HEADER
 from mutagen.mp3 import MP3
 from mutagen.id3 import ID3, APIC, error, TRCK, TIT2, TALB, TPE1, TDRC
 from config import NAME_SANITIZE_REGEX
@@ -63,7 +64,7 @@ def save_audio(trackname, link, outpath):
         print("\tThis track already exists in the directory. Skipping download!")
         return None
     
-    audio_response = requests.get(link)
+    audio_response = requests.get(link, headers=PURR_HEADER)
 
     if audio_response.status_code == 200:
         temp_file = os.path.join(outpath, f"temp_{trackname}.mp3")

--- a/spotify_api.py
+++ b/spotify_api.py
@@ -7,9 +7,9 @@ def get_track_info(link, token):
     response = requests.get(f"https://api.spotidownloader.com/download/{track_id}?token={token}", headers=CUSTOM_HEADER)
     return response.json()
 
-def get_playlist_info(link, trackname_convention, mode):
+def get_playlist_info(link, trackname_convention, mode, token):
     playlist_id = link.split("/")[-1].split("?")[0]
-    response = requests.get(f"https://api.spotidownloader.com/metadata/{mode}/{playlist_id}", headers=CUSTOM_HEADER)
+    response = requests.get(f"https://api.spotidownloader.com/metadata/{mode}/{playlist_id}?token={token}", headers=CUSTOM_HEADER)
     metadata = response.json()
     playlist_name = metadata['title']
     if metadata['success']:
@@ -18,12 +18,12 @@ def get_playlist_info(link, trackname_convention, mode):
     
     print(f"Getting songs from {mode} (this might take a while ...)")
     track_list = []
-    response = requests.get(f"https://api.spotidownloader.com/tracks/{mode}/{playlist_id}", headers=CUSTOM_HEADER)
+    response = requests.get(f"https://api.spotidownloader.com/tracks/{mode}/{playlist_id}?token={token}", headers=CUSTOM_HEADER)
     tracks_data = response.json()
     track_list.extend(tracks_data['trackList'])
     next_offset = tracks_data['nextOffset']
     while next_offset:
-        response = requests.get(f"https://api.spotidownloader.com/tracks/{mode}/{playlist_id}?offset={next_offset}", headers=CUSTOM_HEADER)
+        response = requests.get(f"https://api.spotidownloader.com/tracks/{mode}/{playlist_id}?offset={next_offset}&token={token}", headers=CUSTOM_HEADER)
         tracks_data = response.json()
         track_list.extend(tracks_data['trackList'])
         next_offset = tracks_data['nextOffset']

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import time
 from config import NAME_SANITIZE_REGEX
 from models import Song
 
@@ -70,16 +71,19 @@ def trackname_convention():
         return "Title - Artist", 1
 
 def get_token(reset=False):
-    if os.path.exists("./.cache") and not reset:
-        with open(".cache") as f:
-            token = json.load(f).get("token")
+    cache_file = "./.cache"
+    if os.path.exists(cache_file) and not reset:
 
-    else:
+        file_age = time.time() - os.path.getmtime(cache_file)
+
+        if file_age > 540:
+            reset = True
+
+    if reset or not os.path.exists(cache_file):
         token = input("Enter Token: ").strip()
-        with open(".cache", "w") as f:
-            json.dump(
-            {
-                "token": token,
-            }, f
-        )
+        with open(cache_file, "w") as f:
+            json.dump({"token": token}, f)
+    else:
+        with open(cache_file) as f:
+            token = json.load(f).get("token")
     return token


### PR DESCRIPTION
playlist apis now require a token too this pr also adds a 9 minutes expiry on the cache file

I've added the expiry because otherwise the code gets to `get_playlist_info` with an invalid token and figured it was easier to just make sure we refresh the token when it expires based on the time it was last modified.